### PR TITLE
feat: 修复类型展示问题、修改文章展示样式

### DIFF
--- a/scripts/ts.html-generator.js
+++ b/scripts/ts.html-generator.js
@@ -45,7 +45,8 @@ const htmlTargetPath = './src/html/target';// html 生成后 ts 文件路径
 
 // 生成 ts 文件的入口函数，主要是遍历 src 目录下所有 html 文件。
 const generator = () => {
-  const htmlFileNameList = fs.readdirSync(htmlSrcPath);
+  // 过滤非html文件
+  const htmlFileNameList = fs.readdirSync(htmlSrcPath).filter(name => name.endsWith('html'));
   htmlFileNameList.forEach(htmlFileName => {
     const htmlStr = converter(path.resolve(htmlSrcPath, htmlFileName));
     if (!fs.existsSync(htmlTargetPath)) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -115,7 +115,7 @@ export function activate(context: vscode.ExtensionContext) {
     function getMetaData() {
       let defaultCategory = vscode.workspace
         .getConfiguration()
-        .get("juejin.post.default-category");
+        .get("juejin.post.default-category") || '前端'; // 增加未配置分类时设置前端为默认分类
       return { defaultCategory };
     }
 

--- a/src/html/src/juejin-post.html
+++ b/src/html/src/juejin-post.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>掘金-文章</title>
     <style>
+      ::-webkit-scrollbar {
+        height: 0;
+      }
       .actions {
         padding: 10px 20px;
         position: sticky;
@@ -37,10 +40,11 @@
         height: 26px;
         background-color: var(--vscode-editor-background);
         display: flex;
-        justify-content: space-around;
-        min-width: 600px;
+        width: 100%;
         z-index: 1200;
         padding: 10px 0;
+        overflow-x: overlay;
+        white-space: nowrap;
         /* box-sizing: border-box; */
       }
       .category > div {
@@ -50,6 +54,7 @@
         user-select: none;
         box-sizing: border-box;
         color: #ffffff;
+        margin-left: 10px;
         border: 1px solid var(--vscode-activityBarBadge-background);
       }
       .category > div:hover {
@@ -386,7 +391,14 @@
             // return html;
             // 覆盖样式
             let overrideStyle = document.createElement("style");
+            // 样式覆盖：背景和字体颜色自动适配编辑器主题颜色
             overrideStyle.textContent = `
+              html {
+                background-color: inherit;
+              }
+              .markdown-body {
+                color: inherit;
+              }
               .main-area[data-v-7407bc26] {
                 background-color: var(--vscode-editor-background) !important;
               }
@@ -404,9 +416,7 @@
             let script = tempEl.querySelectorAll("script");
             let link = tempEl.querySelectorAll("link");
             let juejinRootEl = tempEl.querySelector("#juejin");
-            console.log("j,", juejinRootEl);
             juejinRootEl = juejinRootEl.querySelector("article");
-
             window.overrideStyle = overrideStyle;
             // 从掘金接口获取到的 html 只有 data-src，而不是直接在 background-image 中设置src的。
             // 所以要在这里通过 js 添加图片。

--- a/src/html/target/juejin-post.ts
+++ b/src/html/target/juejin-post.ts
@@ -5,6 +5,9 @@ export default `<!DOCTYPE html>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>掘金-文章</title>
     <style>
+      ::-webkit-scrollbar {
+        height: 0;
+      }
       .actions {
         padding: 10px 20px;
         position: sticky;
@@ -37,10 +40,11 @@ export default `<!DOCTYPE html>
         height: 26px;
         background-color: var(--vscode-editor-background);
         display: flex;
-        justify-content: space-around;
-        min-width: 600px;
+        width: 100%;
         z-index: 1200;
         padding: 10px 0;
+        overflow-x: overlay;
+        white-space: nowrap;
         /* box-sizing: border-box; */
       }
       .category > div {
@@ -50,6 +54,7 @@ export default `<!DOCTYPE html>
         user-select: none;
         box-sizing: border-box;
         color: #ffffff;
+        margin-left: 10px;
         border: 1px solid var(--vscode-activityBarBadge-background);
       }
       .category > div:hover {
@@ -345,7 +350,7 @@ export default `<!DOCTYPE html>
                 <div class="post-title" onclick="toPost('\${originalUrl}', '\${id}')">\${title}</div>
                 <div>
                   <span>\${username} · \${time} · \${tags
-                  .map((tag) => tag.title)
+                  .map((tag) => tag.tag_name)
                   .join("/")}</span>
                 </div>
                 </div>\`;
@@ -383,9 +388,17 @@ export default `<!DOCTYPE html>
           data: post,
           generator(data) {
             let { html, detailData } = data;
+            // return html;
             // 覆盖样式
             let overrideStyle = document.createElement("style");
+            // 样式覆盖：背景和字体颜色自动适配编辑器主题颜色
             overrideStyle.textContent = \`
+              html {
+                background-color: inherit;
+              }
+              .markdown-body {
+                color: inherit;
+              }
               .main-area[data-v-7407bc26] {
                 background-color: var(--vscode-editor-background) !important;
               }
@@ -424,8 +437,12 @@ export default `<!DOCTYPE html>
             let avatarEl = juejinRootEl.querySelector(".avatar");
             avatarEl.style.backgroundImage = \`url(\${avatarLarge})\`;
             avatarEl.style.backgroundColor = \`transparent\`;
-            let usernamerEl = juejinRootEl.querySelector(".username");
-            usernamerEl.textContent = username;
+            juejinRootEl.removeChild(
+              juejinRootEl.querySelector(".author-info-block")
+            );
+            // TODO: DOM 结构发生了变化
+            // let usernamerEl = juejinRootEl.querySelector(".author-info-box");
+            // usernamerEl.textContent = username;
             let result = [
               ...meta,
               ...style,


### PR DESCRIPTION
1、修复类型展示不全问题，增加横向滚动
2、当类型没有配置时，默认设置为【前端】类型
3、覆盖文章页面背景色和字体颜色，适配Vscode主题
4、html生成脚本增加html文件过滤